### PR TITLE
refactor: move runners resource adapter registration to constructors

### DIFF
--- a/.github/workflows/buildAndTest.yaml
+++ b/.github/workflows/buildAndTest.yaml
@@ -11,8 +11,19 @@ jobs:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v4
-    - name: building and testing
+    - name: build
+      run: |
+        #-DCMAKE_POLICY_VERSION_MINIMUM=3.5 to workaround xiph ogg / vorbis cmake version issues in github workflows
+        cmake_options="-DCMAKE_POLICY_VERSION_MINIMUM=3.5" ./cmakew . 
+    - name: test
       run: |
         #exclude opengl tests since it does not initialize properly
         #-DCMAKE_POLICY_VERSION_MINIMUM=3.5 to workaround xiph ogg / vorbis cmake version issues in github workflows
         cmake_options="-DCMAKE_POLICY_VERSION_MINIMUM=3.5" cmake_test_options="-E "".*OpenGL.*" ./cmakew -t . 
+    - name: Publish Test Report
+      uses: dorny/test-reporter@v1
+      if: always() # Run even if tests fail
+      with:
+        name: CTest Results
+        path: build/ctest-report.xml
+        reporter: java-junit # Works for any JUnit-formatted XML

--- a/cmakew
+++ b/cmakew
@@ -109,7 +109,7 @@ cmake --build .
 
 ## test
 if [[ "${inputs_parameters_test}" == "true" ]]; then
-  ctest ${cmake_test_options} --output-on-failure
+  ctest ${cmake_test_options} --output-on-failure --output-junit ctest-report.xml
 fi
 
 popd > /dev/null

--- a/src/runners/base/audio/AudioRunner.h
+++ b/src/runners/base/audio/AudioRunner.h
@@ -19,16 +19,13 @@ class AudioRunner: public PlaygroundRunner {
 	protected:
 		Logger *logger = LoggerFactory::getLogger("audio/AudioRunner");
 	public:
-		using PlaygroundRunner::PlaygroundRunner; //inherit constructors
+		AudioRunner(Playground &container) : PlaygroundRunner(container) {
+			this->getResourceManager().addAdapter<OggResourceAdapter>();
+			this->getResourceManager().addAdapter<WavResourceAdapter>();
+		}
 
 		virtual unsigned char getId() const override {
 			return ID;
-		}
-
-		virtual bool initialize() override {
-			this->getResourceManager().addAdapter<OggResourceAdapter>();
-			this->getResourceManager().addAdapter<WavResourceAdapter>();
-			return true;
 		}
 
 		/**

--- a/src/runners/base/video/VideoRunner.h
+++ b/src/runners/base/video/VideoRunner.h
@@ -34,7 +34,16 @@ protected:
 	unsigned int width = 0;
 public:
 
-	using PlaygroundRunner::PlaygroundRunner; //inherit constructors
+	VideoRunner(Playground &container) : PlaygroundRunner(container) {
+		this->getResourceManager().addAdapter<PngResourceAdapter>();
+		this->getResourceManager().addAdapter<JpegResourceAdapter>();
+		this->getResourceManager().addAdapter<TgaResourceAdapter>();
+		this->getResourceManager().addAdapter<GeometryResourceAdapter>();
+		this->getResourceManager().addAdapter<ObjResourceAdapter>();
+		this->getResourceManager().addAdapter<MtlResourceAdapter>();
+		this->getResourceManager().addAdapter<HeightMapResourceAdapter>();
+		this->getResourceManager().addAdapter<TrueTypeResourceAdapter>();
+	}
 
 	virtual unsigned char getId() const override {
 		return ID;
@@ -73,19 +82,6 @@ public:
 
 
 	virtual void setMousePosition(unsigned int x, unsigned int y) = 0;
-
-	virtual bool initialize() override {
-		this->getResourceManager().addAdapter<PngResourceAdapter>();
-		this->getResourceManager().addAdapter<JpegResourceAdapter>();
-		this->getResourceManager().addAdapter<TgaResourceAdapter>();
-		this->getResourceManager().addAdapter<GeometryResourceAdapter>();
-		this->getResourceManager().addAdapter<ObjResourceAdapter>();
-		this->getResourceManager().addAdapter<MtlResourceAdapter>();
-    this->getResourceManager().addAdapter<HeightMapResourceAdapter>();
-    this->getResourceManager().addAdapter<TrueTypeResourceAdapter>();
-
-		return true;
-	}
 
 	/**
 	 * Shader methods - should this go to a shader class?

--- a/src/runners/openAL/OpenALRunner.h
+++ b/src/runners/openAL/OpenALRunner.h
@@ -6,6 +6,7 @@
  */
 
 #pragma once
+#include <stdexcept>
 #include <Math3d.h>
 #include "AudioRunner.h"
 #include "al.h"
@@ -24,22 +25,17 @@ class OpenALRunner: public AudioRunner {
   OpenALRunner(Playground &container) : AudioRunner(container) {
     //this->getResourceManager().addAdapter<SourceResourceAdapter>();
     this->getResourceManager().addAdapter<AudioBufferResourceAdapter>();
-  }
 
-  virtual bool initialize() override {
     device = alcOpenDevice(null);
     if (device == null) {
-      logger->error("Error opening alcDevice");
-      return false;
+      throw std::runtime_error("Error opening alcDevice");
     }
 
     logger->debug("OpenAL device opened");
 
     context = alcCreateContext(device, null);
-    if (context == null)
-    {
-      logger->error("Error creating context");
-      return false;
+    if (context == null) {
+      throw std::runtime_error("Error creating OpenAL context");
     }
 
     logger->debug("OpenAL context created");
@@ -56,8 +52,6 @@ class OpenALRunner: public AudioRunner {
         alGetString(AL_EXTENSIONS));
 
     updateListener(vector(0, 0, 0));
-
-    return true;
   }
 
   virtual String toString() const override {

--- a/src/runners/openAL/OpenALRunner.h
+++ b/src/runners/openAL/OpenALRunner.h
@@ -21,13 +21,12 @@ class OpenALRunner: public AudioRunner {
   ALCdevice *device = null;
   ALCcontext *context = null;
   public:
-  using AudioRunner::AudioRunner; //inherit constructors
-
-  virtual bool initialize() override {
-    AudioRunner::initialize();
+  OpenALRunner(Playground &container) : AudioRunner(container) {
     //this->getResourceManager().addAdapter<SourceResourceAdapter>();
     this->getResourceManager().addAdapter<AudioBufferResourceAdapter>();
+  }
 
+  virtual bool initialize() override {
     device = alcOpenDevice(null);
     if (device == null) {
       logger->error("Error opening alcDevice");

--- a/src/runners/openGL/OpenGLRunner.h
+++ b/src/runners/openGL/OpenGLRunner.h
@@ -51,7 +51,16 @@ private:
 
 public:
 
-  using VideoRunner::VideoRunner;
+  OpenGLRunner(Playground &container) : VideoRunner(container) {
+    this->getResourceManager().addAdapter<TextureResourceAdapter>();
+    this->getResourceManager().addAdapter<CubeMapResourceAdapter>();
+    this->getResourceManager().addAdapter<VertexArrayResourceAdapter>();
+    this->getResourceManager().addAdapter<MeshResourceAdapter>();
+    this->getResourceManager().addAdapter<VertexShaderResourceAdapter>();
+    this->getResourceManager().addAdapter<FragmentShaderResourceAdapter>();
+    this->getResourceManager().addAdapter<ShaderProgramResourceAdapter>();
+    this->getResourceManager().addAdapter<TerrainResourceAdapter>();
+  }
 
   virtual unsigned char getInterests() const override {
     return RESIZE | KEY_DOWN;
@@ -75,17 +84,7 @@ public:
   }
 
   virtual bool initialize() override {
-    //logger->setLogLevel(LogLevel::DEBUG);
-    VideoRunner::initialize();
-    this->getResourceManager().addAdapter<TextureResourceAdapter>();
-    this->getResourceManager().addAdapter<CubeMapResourceAdapter>();
-    this->getResourceManager().addAdapter<VertexArrayResourceAdapter>();
-    this->getResourceManager().addAdapter<MeshResourceAdapter>();
-    this->getResourceManager().addAdapter<VertexShaderResourceAdapter>();
-    this->getResourceManager().addAdapter<FragmentShaderResourceAdapter>();
-    this->getResourceManager().addAdapter<ShaderProgramResourceAdapter>();
-    this->getResourceManager().addAdapter<TerrainResourceAdapter>();
-
+    //logger->setLogLevel(LogLevel::DEBUG)
     if (!SDL_Init(SDL_INIT_VIDEO)) {
       logger->error("SDL_Init Error: %s", SDL_GetError() == null ? "" : SDL_GetError());
       return false;

--- a/src/runners/openGL/OpenGLRunner.h
+++ b/src/runners/openGL/OpenGLRunner.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <unistd.h>
+#include <stdexcept>
 
 #define GL_SILENCE_DEPRECATION //hide opengl deprecated on osx warnings
 #include <OpenGL/OpenGL.h>
@@ -60,6 +61,54 @@ public:
     this->getResourceManager().addAdapter<FragmentShaderResourceAdapter>();
     this->getResourceManager().addAdapter<ShaderProgramResourceAdapter>();
     this->getResourceManager().addAdapter<TerrainResourceAdapter>();
+
+    if (!SDL_Init(SDL_INIT_VIDEO)) {
+      throw std::runtime_error(String("SDL_Init Error: ") + (SDL_GetError() == null ? "" : SDL_GetError()));
+    }
+
+    logger->debug("SDL initialized");
+
+    SDL_SetLogPriorities(SDL_LOG_PRIORITY_INFO);
+
+    this->window = SDL_CreateWindow("SDL2/OpenGL Demo", 640, 480, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE);
+    logger->debug("SDL Window created");
+
+    SDL_AddEventWatch(playgroundEventFilter, this);
+    logger->debug("SDL event watch registered");
+
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 2);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
+    SDL_GL_SetAttribute(SDL_GL_ACCELERATED_VISUAL, 1);
+    SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
+    SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 24);
+    if ((glcontext = SDL_GL_CreateContext(window)) == null) {
+      throw std::runtime_error(String("SDL_GL_CreateContext Error: ") + (SDL_GetError() == null ? "" : SDL_GetError()));
+    }
+
+    int majorVersion;
+    int minorVersion;
+
+    glGetIntegerv(GL_MAJOR_VERSION, &majorVersion);
+    glGetIntegerv(GL_MINOR_VERSION, &minorVersion);
+    this->majorVersion = (unsigned int) majorVersion;
+    this->minorVersion = (unsigned int) minorVersion;
+
+    logger->info("\nOpenGL [%d].[%d] initialized\n\tVersion: [%s]\n\tGLSL Version: [%s]\n\tGLEW Version [%s]\n\tVendor: [%s]\n\tRenderer: [%s]",
+        this->majorVersion, this->minorVersion,
+        glGetString(GL_VERSION),
+        glGetString(GL_SHADING_LANGUAGE_VERSION),
+        "0", //glewGetString(GLEW_VERSION),
+        glGetString(GL_VENDOR),
+        glGetString(GL_RENDERER));
+
+    defaultTexture = new TextureResource(this->generateDefaultTexture());
+    defaultTexture->setUri("OpenGLRunner::defaultTextureResource");
+    this->getContainer().getResourceManager().addResource(defaultTexture);
+
+    if (!SDL_Init(SDL_INIT_GAMEPAD)) {
+      throw std::runtime_error(String("SDL_Init gamepad Error: ") + (SDL_GetError() == null ? "" : SDL_GetError()));
+    }
   }
 
   virtual unsigned char getInterests() const override {
@@ -81,68 +130,6 @@ public:
     }
     SDL_Quit();
     logger->info("SDL shutdown");
-  }
-
-  virtual bool initialize() override {
-    //logger->setLogLevel(LogLevel::DEBUG)
-    if (!SDL_Init(SDL_INIT_VIDEO)) {
-      logger->error("SDL_Init Error: %s", SDL_GetError() == null ? "" : SDL_GetError());
-      return false;
-    }
-
-    logger->debug("SDL initialized");
-
-    SDL_SetLogPriorities(SDL_LOG_PRIORITY_INFO);
-
-    this->window = SDL_CreateWindow("SDL2/OpenGL Demo", 640, 480, SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE);
-    logger->debug("SDL Window created");
-
-//        SDL_PumpEvents();
-//        SDL_SetRelativeMouseMode(true);
-    SDL_AddEventWatch(playgroundEventFilter, this);
-
-    logger->debug("SDL event watch registered");
-
-    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
-    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 2);
-    SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
-    SDL_GL_SetAttribute(SDL_GL_ACCELERATED_VISUAL, 1);
-    SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
-    SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 24);
-    if ((glcontext = SDL_GL_CreateContext(window)) == null) {
-      logger->error("SDL_GL_CreateContext Error: %s", SDL_GetError());
-      return false;
-    }
-
-    int majorVersion;
-    int minorVersion;
-
-    glGetIntegerv(GL_MAJOR_VERSION, &majorVersion);
-    glGetIntegerv(GL_MINOR_VERSION, &minorVersion);
-    this->majorVersion = (unsigned int) majorVersion;
-    this->minorVersion = (unsigned int) minorVersion;
-
-    logger->info("\nOpenGL [%d].[%d] initialized\n\tVersion: [%s]\n\tGLSL Version: [%s]\n\tGLEW Version [%s]\n\tVendor: [%s]\n\tRenderer: [%s]",
-        this->majorVersion, this->minorVersion,
-        glGetString(GL_VERSION),
-        glGetString(GL_SHADING_LANGUAGE_VERSION),
-        "0", //glewGetString(GLEW_VERSION),
-        glGetString(GL_VENDOR),
-        glGetString(GL_RENDERER));
-
-    /**
-     * OpenGL defaults so that something is rendered with minimum configuration.
-     */
-    defaultTexture = new TextureResource(this->generateDefaultTexture());
-    defaultTexture->setUri("OpenGLRunner::defaultTextureResource");
-    this->getContainer().getResourceManager().addResource(defaultTexture);
-
-    if (!SDL_Init(SDL_INIT_GAMEPAD)) {
-      logger->error("SDL_Init Error: %s", SDL_GetError());
-      return false;
-    }
-
-    return true;
   }
 
   virtual bool afterInitialize() override {


### PR DESCRIPTION
Move addAdapter calls from initialize() to constructors in AudioRunner, VideoRunner, OpenALRunner and OpenGLRunner. This ensures resource adapters are registered as part of object construction rather than deferred initialization.